### PR TITLE
Add comprehensive repetitive regions analysis for Flye vs Canu comparison

### DIFF
--- a/assembly2/memo/repetitive-regions-analysis.md
+++ b/assembly2/memo/repetitive-regions-analysis.md
@@ -1,0 +1,125 @@
+# Repetitive Regions Analysis: Flye vs Canu Assembly Comparison
+
+## Background
+The BUSCO and QUAST results in the scaffolding assessment show differences between Flye and Canu assemblies, with these differences likely stemming from how each assembler handles repetitive regions.
+
+## Key Differences Between Flye and Canu in Repetitive Region Handling
+
+### Flye's Approach
+- **Algorithm**: Uses repeat graph algorithm that generates arbitrary paths (disjointigs) in unknown repeat graphs
+- **Strategy**: More aggressive in resolving repetitive regions
+- **Strengths**: Better at resolving complex repeat structures, faster assembly
+- **Weaknesses**: May produce chimeric scaffolds, especially at chromosome ends/telomeres
+- **Best for**: Exons, introns, small RNAs, UTRs
+
+### Canu's Approach  
+- **Algorithm**: Uses modified string graph algorithm with strict criteria for repetitive sequence connections
+- **Strategy**: Conservative approach to repeat resolution
+- **Strengths**: More accurate in highly repetitive regions, avoids chromosomal fusion artifacts
+- **Weaknesses**: May be overly conservative, leaving some repeats unresolved
+- **Best for**: Pseudogenes, repeats, transposable elements
+
+## Research Findings Summary
+
+### Assembly Quality Differences
+1. **Chromosomal Fusion Issues**: Flye shows chimeric scaffolds with end-to-end chromosome connections due to failure in resolving repetitive sequences at chromosome ends
+2. **Telomeric Regions**: Canu never showed chromosomal fusion in telomeric regions due to strict repetitive sequence connection criteria
+3. **Complementary Strengths**: Flye better for gene identification, Canu superior for natural transposon analysis
+
+## Methods and Tools for Analyzing Repetitive Regions
+
+### 1. Quality Assessment Tools
+
+#### QUAST (Quality Assessment Tool for Genome Assemblies)
+- **Purpose**: Evaluates and compares genome assemblies with/without reference
+- **Key Metrics**: 
+  - Duplication ratio (measures contigs mapping to multiple locations)
+  - NG50 (uses estimated genome size rather than assembly length)
+  - Genome fraction calculations
+- **Repetitive Region Analysis**: Identifies contigs from repeat regions that map to multiple places
+
+#### GenomeQC
+- **Purpose**: Quality assessment with gene structure annotation support
+- **Features**: Determines completeness of repetitive fraction based on LTR retrotransposon content
+
+### 2. Specialized Repetitive Element Detection Tools
+
+#### RepeatModeler2
+- **Purpose**: De novo transposable element family identification and modeling
+- **Components**: 
+  - RECON (repeat identification)
+  - RepeatScout (repeat discovery)
+  - LTRharvest/LTR_retriever (structure-based methods)
+  - Dfam database integration
+- **Input**: Genome assemblies (not reads)
+- **Output**: High-quality TE family library for RepeatMasker
+
+#### RepeatMasker
+- **Purpose**: Screens DNA sequences for interspersed repeats and low complexity sequences
+- **Function**: Annotates and masks repetitive elements using existing libraries
+- **Output**: Detailed repeat annotations and masked sequences
+
+#### TRF (Tandem Repeat Finder)
+- **Purpose**: Locates and displays tandem repeats in DNA sequences
+- **Features**: 
+  - No need to specify pattern or parameters
+  - Identifies adjacent, approximate copies of nucleotide patterns
+  - Required for RepeatModeler (version 4.0.9+)
+
+### 3. Assembly Evaluation Methods
+
+#### Reference-Independent Tools
+- **ALE (Assembly Likelihood Framework)**: Uses read alignments for assembly evaluation
+- **REAPR**: Universal genome assembly evaluation tool
+- **Compass**: Estimates genome coverage, validity, multiplicity, and parsimony
+
+#### K-mer Spectral Analysis
+- **Purpose**: Compares k-mer spectra between reads and assemblies
+- **Advantage**: More direct accuracy measurement, eliminates mapping-induced differences
+
+## Recommended Analysis Workflow
+
+### Standard Pipeline
+1. **Dustmasker**: Low complexity sequence masking
+2. **TRF**: Tandem repeat identification
+3. **RepeatModeler**: De novo repeat family discovery
+4. **RepeatMasker**: Repeat annotation and masking
+
+### Comparative Analysis Steps
+1. **Quality Assessment**: 
+   - Run QUAST on both Flye and Canu assemblies
+   - Compare duplication ratios and NG50 values
+   - Analyze genome fraction coverage
+
+2. **Repetitive Element Profiling**:
+   - Run RepeatModeler on both assemblies
+   - Compare repeat family libraries
+   - Analyze transposable element content
+
+3. **Structural Analysis**:
+   - Generate dot plots comparing assemblies
+   - Identify chromosomal fusion events
+   - Assess telomeric region integrity
+
+4. **BUSCO Analysis**:
+   - Compare gene completeness scores
+   - Analyze duplicated vs missing genes
+   - Correlate with repetitive region resolution
+
+## Technical Considerations
+
+### Sequencing Technology Impact
+- **Long-read advantages**: Better resolution of repetitive regions (PacBio: 8-40kb, ONT: up to 2Mb)
+- **10xGC technology**: High-quality assembly at lower cost
+- **Optical mapping**: Assists in resolving repetitive regions and scaffolding
+
+### Assembly Challenges
+- **Large plant genomes**: High levels of repeated/duplicated sequences
+- **Short-read limitations**: Poor resolution of repeats leading to chimeric sequences
+- **Heuristic differences**: Different assembly programs use different approaches
+
+## Conclusion
+
+The differences between Flye and Canu assemblies in repetitive regions reflect their fundamental algorithmic approaches. Flye's aggressive repeat resolution may provide better contiguity but risks misassemblies, while Canu's conservative approach ensures accuracy but may leave some repeats unresolved. The choice depends on the specific research goals and downstream applications.
+
+For comprehensive analysis, both assemblies should be evaluated using the tools and methods outlined above, with particular attention to the specific types of repetitive elements present in the target genome.

--- a/assembly2/memo/repetitive-regions-analysis.md
+++ b/assembly2/memo/repetitive-regions-analysis.md
@@ -1,125 +1,125 @@
-# Repetitive Regions Analysis: Flye vs Canu Assembly Comparison
+# 反復領域解析: FlyeとCanuアセンブリの比較
 
-## Background
-The BUSCO and QUAST results in the scaffolding assessment show differences between Flye and Canu assemblies, with these differences likely stemming from how each assembler handles repetitive regions.
+## 背景
+スキャフォールディング評価におけるBUSCOとQUASTの結果は、FlyeとCanuアセンブリの間に差異があることを示しており、これらの差異は各アセンブラーが反復領域をどのように処理するかに起因していると考えられます。
 
-## Key Differences Between Flye and Canu in Repetitive Region Handling
+## 反復領域処理におけるFlyeとCanuの主な違い
 
-### Flye's Approach
-- **Algorithm**: Uses repeat graph algorithm that generates arbitrary paths (disjointigs) in unknown repeat graphs
-- **Strategy**: More aggressive in resolving repetitive regions
-- **Strengths**: Better at resolving complex repeat structures, faster assembly
-- **Weaknesses**: May produce chimeric scaffolds, especially at chromosome ends/telomeres
-- **Best for**: Exons, introns, small RNAs, UTRs
+### Flyeのアプローチ
+- **アルゴリズム**: 未知の反復グラフで任意のパス（disjointigs）を生成する反復グラフアルゴリズムを使用
+- **戦略**: 反復領域の解決により積極的
+- **強み**: 複雑な反復構造の解決が優れている、高速なアセンブリ
+- **弱み**: 特に染色体末端/テロメアでキメラスキャフォールドを生成する可能性
+- **最適用途**: エクソン、イントロン、小RNA、UTR
 
-### Canu's Approach  
-- **Algorithm**: Uses modified string graph algorithm with strict criteria for repetitive sequence connections
-- **Strategy**: Conservative approach to repeat resolution
-- **Strengths**: More accurate in highly repetitive regions, avoids chromosomal fusion artifacts
-- **Weaknesses**: May be overly conservative, leaving some repeats unresolved
-- **Best for**: Pseudogenes, repeats, transposable elements
+### Canuのアプローチ  
+- **アルゴリズム**: 反復配列接続に厳格な基準を持つ修正されたストリンググラフアルゴリズムを使用
+- **戦略**: 反復解決に対する保守的アプローチ
+- **強み**: 高度に反復的な領域でより正確、染色体融合アーティファクトを回避
+- **弱み**: 過度に保守的になり、一部の反復が未解決のまま残る可能性
+- **最適用途**: 偽遺伝子、反復配列、転移因子
 
-## Research Findings Summary
+## 研究結果まとめ
 
-### Assembly Quality Differences
-1. **Chromosomal Fusion Issues**: Flye shows chimeric scaffolds with end-to-end chromosome connections due to failure in resolving repetitive sequences at chromosome ends
-2. **Telomeric Regions**: Canu never showed chromosomal fusion in telomeric regions due to strict repetitive sequence connection criteria
-3. **Complementary Strengths**: Flye better for gene identification, Canu superior for natural transposon analysis
+### アセンブリ品質の違い
+1. **染色体融合問題**: Flyeは染色体末端での反復配列解決の失敗により、染色体間の端と端の接続を持つキメラスキャフォールドを示す
+2. **テロメア領域**: Canuは反復配列接続の厳格な基準により、テロメア領域で染色体融合を示すことがない
+3. **相補的な強み**: Flyeは遺伝子同定により優れ、Canuは天然トランスポゾン解析で優位
 
-## Methods and Tools for Analyzing Repetitive Regions
+## 反復領域解析のための手法とツール
 
-### 1. Quality Assessment Tools
+### 1. 品質評価ツール
 
 #### QUAST (Quality Assessment Tool for Genome Assemblies)
-- **Purpose**: Evaluates and compares genome assemblies with/without reference
-- **Key Metrics**: 
-  - Duplication ratio (measures contigs mapping to multiple locations)
-  - NG50 (uses estimated genome size rather than assembly length)
-  - Genome fraction calculations
-- **Repetitive Region Analysis**: Identifies contigs from repeat regions that map to multiple places
+- **目的**: 参照ありなしでゲノムアセンブリを評価・比較
+- **主要指標**: 
+  - 重複比率（複数の場所にマップするコンティグを測定）
+  - NG50（アセンブリ長ではなく推定ゲノムサイズを使用）
+  - ゲノム分画計算
+- **反復領域解析**: 複数の場所にマップする反復領域由来のコンティグを特定
 
 #### GenomeQC
-- **Purpose**: Quality assessment with gene structure annotation support
-- **Features**: Determines completeness of repetitive fraction based on LTR retrotransposon content
+- **目的**: 遺伝子構造アノテーションサポート付き品質評価
+- **機能**: LTRレトロトランスポゾン含有量に基づく反復分画の完全性を決定
 
-### 2. Specialized Repetitive Element Detection Tools
+### 2. 専門的反復要素検出ツール
 
 #### RepeatModeler2
-- **Purpose**: De novo transposable element family identification and modeling
-- **Components**: 
-  - RECON (repeat identification)
-  - RepeatScout (repeat discovery)
-  - LTRharvest/LTR_retriever (structure-based methods)
-  - Dfam database integration
-- **Input**: Genome assemblies (not reads)
-- **Output**: High-quality TE family library for RepeatMasker
+- **目的**: デノボ転移因子ファミリーの同定とモデル化
+- **構成要素**: 
+  - RECON（反復同定）
+  - RepeatScout（反復発見）
+  - LTRharvest/LTR_retriever（構造ベース手法）
+  - Dfamデータベース統合
+- **入力**: ゲノムアセンブリ（リードではない）
+- **出力**: RepeatMasker用の高品質TEファミリーライブラリ
 
 #### RepeatMasker
-- **Purpose**: Screens DNA sequences for interspersed repeats and low complexity sequences
-- **Function**: Annotates and masks repetitive elements using existing libraries
-- **Output**: Detailed repeat annotations and masked sequences
+- **目的**: 散在反復と低複雑度配列についてDNA配列をスクリーニング
+- **機能**: 既存ライブラリを使用して反復要素をアノテーション・マスク
+- **出力**: 詳細な反復アノテーションとマスク配列
 
 #### TRF (Tandem Repeat Finder)
-- **Purpose**: Locates and displays tandem repeats in DNA sequences
-- **Features**: 
-  - No need to specify pattern or parameters
-  - Identifies adjacent, approximate copies of nucleotide patterns
-  - Required for RepeatModeler (version 4.0.9+)
+- **目的**: DNA配列内のタンデム反復の特定と表示
+- **機能**: 
+  - パターンやパラメータの指定不要
+  - 隣接する近似的なヌクレオチドパターンのコピーを特定
+  - RepeatModeler（バージョン4.0.9+）に必要
 
-### 3. Assembly Evaluation Methods
+### 3. アセンブリ評価手法
 
-#### Reference-Independent Tools
-- **ALE (Assembly Likelihood Framework)**: Uses read alignments for assembly evaluation
-- **REAPR**: Universal genome assembly evaluation tool
-- **Compass**: Estimates genome coverage, validity, multiplicity, and parsimony
+#### 参照非依存ツール
+- **ALE (Assembly Likelihood Framework)**: アセンブリ評価にリードアライメントを使用
+- **REAPR**: ユニバーサルゲノムアセンブリ評価ツール
+- **Compass**: ゲノムカバレッジ、妥当性、多重度、簡潔性を推定
 
-#### K-mer Spectral Analysis
-- **Purpose**: Compares k-mer spectra between reads and assemblies
-- **Advantage**: More direct accuracy measurement, eliminates mapping-induced differences
+#### K-mer スペクトル解析
+- **目的**: リードとアセンブリ間のk-merスペクトルを比較
+- **利点**: より直接的な精度測定、マッピング誘発差異の除去
 
-## Recommended Analysis Workflow
+## 推奨解析ワークフロー
 
-### Standard Pipeline
-1. **Dustmasker**: Low complexity sequence masking
-2. **TRF**: Tandem repeat identification
-3. **RepeatModeler**: De novo repeat family discovery
-4. **RepeatMasker**: Repeat annotation and masking
+### 標準パイプライン
+1. **Dustmasker**: 低複雑度配列マスキング
+2. **TRF**: タンデム反復同定
+3. **RepeatModeler**: デノボ反復ファミリー発見
+4. **RepeatMasker**: 反復アノテーションとマスキング
 
-### Comparative Analysis Steps
-1. **Quality Assessment**: 
-   - Run QUAST on both Flye and Canu assemblies
-   - Compare duplication ratios and NG50 values
-   - Analyze genome fraction coverage
+### 比較解析ステップ
+1. **品質評価**: 
+   - FlyeとCanuアセンブリの両方でQUASTを実行
+   - 重複比率とNG50値を比較
+   - ゲノム分画カバレッジを解析
 
-2. **Repetitive Element Profiling**:
-   - Run RepeatModeler on both assemblies
-   - Compare repeat family libraries
-   - Analyze transposable element content
+2. **反復要素プロファイリング**:
+   - 両アセンブリでRepeatModelerを実行
+   - 反復ファミリーライブラリを比較
+   - 転移因子含有量を解析
 
-3. **Structural Analysis**:
-   - Generate dot plots comparing assemblies
-   - Identify chromosomal fusion events
-   - Assess telomeric region integrity
+3. **構造解析**:
+   - アセンブリ比較のドットプロットを生成
+   - 染色体融合イベントを特定
+   - テロメア領域の完全性を評価
 
-4. **BUSCO Analysis**:
-   - Compare gene completeness scores
-   - Analyze duplicated vs missing genes
-   - Correlate with repetitive region resolution
+4. **BUSCO解析**:
+   - 遺伝子完全性スコアを比較
+   - 重複 vs 欠失遺伝子を解析
+   - 反復領域解決との相関を分析
 
-## Technical Considerations
+## 技術的考慮事項
 
-### Sequencing Technology Impact
-- **Long-read advantages**: Better resolution of repetitive regions (PacBio: 8-40kb, ONT: up to 2Mb)
-- **10xGC technology**: High-quality assembly at lower cost
-- **Optical mapping**: Assists in resolving repetitive regions and scaffolding
+### シーケンシング技術の影響
+- **ロングリードの利点**: 反復領域のより良い解決（PacBio: 8-40kb、ONT: 最大2Mb）
+- **10xGC技術**: より低コストでの高品質アセンブリ
+- **光学マッピング**: 反復領域の解決とスキャフォールディングを支援
 
-### Assembly Challenges
-- **Large plant genomes**: High levels of repeated/duplicated sequences
-- **Short-read limitations**: Poor resolution of repeats leading to chimeric sequences
-- **Heuristic differences**: Different assembly programs use different approaches
+### アセンブリの課題
+- **大規模植物ゲノム**: 高レベルの反復・重複配列
+- **ショートリードの限界**: 反復の解決が困難でキメラ配列を生成
+- **ヒューリスティック差異**: 異なるアセンブリプログラムが異なるアプローチを使用
 
-## Conclusion
+## 結論
 
-The differences between Flye and Canu assemblies in repetitive regions reflect their fundamental algorithmic approaches. Flye's aggressive repeat resolution may provide better contiguity but risks misassemblies, while Canu's conservative approach ensures accuracy but may leave some repeats unresolved. The choice depends on the specific research goals and downstream applications.
+反復領域におけるFlyeとCanuアセンブリの違いは、それらの基本的なアルゴリズムアプローチを反映しています。Flyeの積極的な反復解決はより良い連続性を提供する可能性がありますが、誤アセンブリのリスクがあります。一方、Canuの保守的アプローチは精度を確保しますが、一部の反復が未解決のままになる可能性があります。選択は特定の研究目標と下流アプリケーションに依存します。
 
-For comprehensive analysis, both assemblies should be evaluated using the tools and methods outlined above, with particular attention to the specific types of repetitive elements present in the target genome.
+包括的な解析のために、両アセンブリは上記に概説したツールと手法を使用して評価されるべきであり、標的ゲノムに存在する反復要素の特定タイプに特別な注意を払う必要があります。


### PR DESCRIPTION
## Summary
- Added detailed analysis document comparing Flye and Canu assemblers' handling of repetitive regions
- Documented research findings on assembly quality differences and chromosomal fusion issues  
- Provided comprehensive methods and tools for analyzing repetitive regions (QUAST, RepeatModeler, RepeatMasker, TRF)
- Added recommended analysis workflow and technical considerations

## Test plan
- [x] Document created in assembly2/memo/repetitive-regions-analysis.md
- [x] Content includes both theoretical background and practical analysis methods
- [x] File follows existing documentation structure and formatting

🤖 Generated with [Claude Code](https://claude.ai/code)